### PR TITLE
:tada: feat: Add styling for `<kbd>` tags

### DIFF
--- a/src/css/output.css
+++ b/src/css/output.css
@@ -130,6 +130,19 @@
 	margin: 1em 0;
 }
 
+#output kbd {
+	background-color: white;
+	margin: 0 0.2em;
+	padding: 0.1em 0.5em;
+
+	border: 1px solid #e0e3e6;
+	border-radius: 3px;
+	box-shadow: 0 2px 0 #e0e3e6;
+
+	line-height: 2;
+	white-space: nowrap;
+}
+
 /* ============================================= DARK THEME ====================================================== */
 
 #output.dark {
@@ -179,6 +192,12 @@
 #output.dark hr {
 	border-color: #30363d;
 	background-color: #30363d;
+}
+
+#output.dark kbd {
+	background-color: black;
+	border-color: #3a424a;
+	box-shadow: 0 2px 0 #3a424a;
 }
 
 /* ================================================ SCROLL BAR (for 'pre' and 'table') =================================================== */

--- a/src/css/output.css
+++ b/src/css/output.css
@@ -131,14 +131,12 @@
 }
 
 #output kbd {
-	background-color: #fafbfc;
+	background-color: #f6f8fa;
 	margin: 0 0.2em;
 	padding: 0.1em 0.5em;
-
-	border: 1px solid #d1d5da;
+	border: 1px solid #dadfe3;
 	border-radius: 6px;
-	box-shadow: 0 2px 0 #d1d5da;
-
+	box-shadow: 0 2px 0 #dadfe3;
 	line-height: 2;
 	white-space: nowrap;
 }
@@ -195,9 +193,9 @@
 }
 
 #output.dark kbd {
-	background-color: #0d1117;
-	border-color: #d1d5da;
-	box-shadow: 0 2px 0 #d1d5da;
+	background-color: #161b22;
+	border-color: #393f48;
+	box-shadow: 0 2px 0 #393f48;
 }
 
 /* ================================================ SCROLL BAR (for 'pre' and 'table') =================================================== */

--- a/src/css/output.css
+++ b/src/css/output.css
@@ -131,13 +131,13 @@
 }
 
 #output kbd {
-	background-color: white;
+	background-color: #fafbfc;
 	margin: 0 0.2em;
 	padding: 0.1em 0.5em;
 
-	border: 1px solid #e0e3e6;
-	border-radius: 3px;
-	box-shadow: 0 2px 0 #e0e3e6;
+	border: 1px solid #d1d5da;
+	border-radius: 6px;
+	box-shadow: 0 2px 0 #d1d5da;
 
 	line-height: 2;
 	white-space: nowrap;
@@ -195,9 +195,9 @@
 }
 
 #output.dark kbd {
-	background-color: black;
-	border-color: #3a424a;
-	box-shadow: 0 2px 0 #3a424a;
+	background-color: #0d1117;
+	border-color: #d1d5da;
+	box-shadow: 0 2px 0 #d1d5da;
 }
 
 /* ================================================ SCROLL BAR (for 'pre' and 'table') =================================================== */

--- a/src/util/initialText.js
+++ b/src/util/initialText.js
@@ -226,6 +226,13 @@ This text is center aligned!
 - Usual **Markdown** works in \`here\`.
 </details>
 
+
+#### Keyboard Tag
+
+The keyboard tag (\`<kbd></kbd>\`) can be used to represent a keyboard input.
+
+Eg: <kbd>Ctrl</kbd> + <kbd>C</kbd>
+
 ## Resources
 
 - [What is Markdown?](https://www.markdownguide.org/getting-started)


### PR DESCRIPTION
Adds both a light and dark theme style for `<kbd>` tags.
Closes #17 

![Example of <kbd> tag](https://user-images.githubusercontent.com/25801283/126047238-4cedd9ab-c926-4580-9287-0e65009f543e.png)
